### PR TITLE
Fix GitHub repository URL in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ I always prefer to work in a virtual environment:
 ```bash
 python3 -m venv ~/heirloom.venv
 source ~/heirloom.venv/bin/activate
-pip install git+https://github.com/heirloom-gm/heirloom-gm
+pip install git+https://github.com/HeirloomGM/heirloom-gm
 ```
 
 


### PR DESCRIPTION
## Fixing Installation instructions
* The repository URL changed: 
  * Instalation instructions altered to follow the new URL