### PR TITLE
Remove max version requirement for PySide6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "InquirerPy",
     "keyring",
     "cryptography",
-    "PySide6>=6.8.0.2,<6.9"
+    "PySide6>=6.8.0.2"
 ]
 requires-python = ">= 3.10"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ rich
 InquirerPy
 cryptography
 keyring
-PySide6>=6.8.0.2,<6.9
+PySide6>=6.8.0.2


### PR DESCRIPTION
I'm using EndeavourOS (Arch), and Heirloom won't build because it can't find the right version of PySide because of the max version requirements set on requirements.txt & pyproject.toml